### PR TITLE
Adds new fields on the entities to verify code

### DIFF
--- a/pynfe/entidades/cliente.py
+++ b/pynfe/entidades/cliente.py
@@ -2,6 +2,7 @@
 from base import Entidade
 from pynfe.utils.flags import TIPOS_DOCUMENTO, CODIGO_BRASIL
 
+
 class Cliente(Entidade):
     # Dados do Cliente
     # - Nome/Razão Social (obrigatorio)
@@ -50,9 +51,11 @@ class Cliente(Entidade):
     # - Municipio (obrigatorio)
     endereco_municipio = str()
 
+    # - Código do Município (opt)
+    endereco_cod_municipio = str()
+
     # - Telefone
     endereco_telefone = str()
 
     def __str__(self):
         return ' '.join([self.tipo_documento, self.numero_documento])
-

--- a/pynfe/entidades/emitente.py
+++ b/pynfe/entidades/emitente.py
@@ -23,7 +23,7 @@ class Emitente(Entidade):
 
     # - Inscricao Estadual (Subst. Tributario)
     inscricao_estadual_subst_tributaria = str()
-    
+
     # - Codigo de Regime Tributario (obrigatorio)
     codigo_de_regime_tributario = str()
 
@@ -52,6 +52,9 @@ class Emitente(Entidade):
     # - Municipio (obrigatorio)
     endereco_municipio = str()
 
+    # - Codigo Municipio (opt)
+    endereco_cod_municipio = str()
+
     # - Telefone
     endereco_telefone = str()
 
@@ -60,4 +63,3 @@ class Emitente(Entidade):
 
     def __str__(self):
         return self.cnpj
-

--- a/pynfe/entidades/notafiscal.py
+++ b/pynfe/entidades/notafiscal.py
@@ -832,6 +832,9 @@ class NotaFiscalEntregaRetirada(Entidade):
     #  - Municipio (obrigatorio)
     endereco_municipio = str()
 
+    # - Código Município (opt)
+    endereco_cod_municipio = str()
+
     #  - Telefone
     endereco_telefone = str()
 

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -352,7 +352,8 @@ class SerializacaoPipes(Serializacao):
     def _serializar_emitente(self, emitente, retorna_string=True):
 
         cod_municipio, municipio = obter_municipio_e_codigo(
-            emitente.endereco_municipio,
+            dict(codigo=emitente.endereco_cod_municipio,
+                municipio=emitente.endereco_municipio),
             emitente.endereco_uf
         )
 
@@ -388,7 +389,8 @@ class SerializacaoPipes(Serializacao):
     def _serializar_cliente(self, cliente, retorna_string=True):
 
         cod_municipio, municipio = obter_municipio_e_codigo(
-            cliente.endereco_municipio,
+            dict(codigo=cliente.endereco_cod_municipio,
+                 municipio=cliente.endereco_municipio),
             cliente.endereco_uf
         )
 
@@ -464,14 +466,14 @@ class SerializacaoPipes(Serializacao):
         ]
 
         if retorna_string:
-            return '|'.join(map(str,serial_data))
+            return '|'.join(map(str, serial_data))
         return serial_data
-
 
     def _serializar_nota_fiscal(self, nota_fiscal, retorna_string=True):
 
         cod_municipio, municipio = obter_municipio_e_codigo(
-            nota_fiscal.municipio,
+            dict(codigo='',
+                 municipio=nota_fiscal.municipio),
             nota_fiscal.uf
         )
 

--- a/pynfe/utils/__init__.py
+++ b/pynfe/utils/__init__.py
@@ -116,23 +116,31 @@ def obter_municipio_por_codigo(codigo, uf, normalizado=False):
     # TODO: fazer UF ser opcional
     municipios = carregar_arquivo_municipios(uf)
     municipio = municipios.get(unicode(codigo))
+    if municipio is None:
+        raise ValueError
     if normalizado:
         return normalizar_municipio(municipio)
-
     return municipio
 
 
 # @memoize
-def obter_municipio_e_codigo(municipio_ou_codigo, uf):
+def obter_municipio_e_codigo(dados, uf):
+    '''Retorna código e município
+    municipio_ou_codigo - espera receber um dicionário no formato:
+        {codigo: 121212, municipio: u'municipio'}
+    '''
+
+    cod = dados.get('codigo', '')
+    mun = normalizar_municipio(dados.get('municipio', ''))
     try:
-        cod_municipio = int(municipio_ou_codigo)
+        cod = int(cod)
     except ValueError:
-        cod_municipio = obter_codigo_por_municipio(municipio_ou_codigo, uf)
-
-    municipio = obter_municipio_por_codigo(cod_municipio, uf, normalizado=True)
-
-    return cod_municipio, municipio
-
+        cod = obter_codigo_por_municipio(mun, uf)
+    # TODO: se ainda com este teste apresentar erros de nessa seção
+    # desenvolver um retorno que informe ao cliente quais nfes estão com erro
+    # e não explodir esse a geração das outras nfes
+    municipio = obter_municipio_por_codigo(cod, uf, normalizado=True)
+    return cod, municipio
 
 # @memoize
 def extrair_tag(root):


### PR DESCRIPTION
- Now obter_municipio_e_codigo expects a dict instead of a str or int
- obter_municipio_por_codigo is deprecated
- Entities now have municipio code as an aditional field
